### PR TITLE
Fix: could not be parsed as it uses an unsupported built-in tag at li…

### DIFF
--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -12,6 +12,6 @@
     - 'Add a command to purge the log after X days and a setting to configure it'
 1.2.0:
     - 'Removed automatic mail purge'
-2.0.0: !!! 'Added in automatic mail log purging. This will automatically purge mail logs that are 30 days or older by default'
+2.0.0: "!!! 'Added in automatic mail log purging. This will automatically purge mail logs that are 30 days or older by default'"
 2.1.0:
     - 'Changed permissions to use default log permissions'


### PR DESCRIPTION
…ne 15

A syntax error was detected in plugins/suresoftware/maillog/updates/version.yaml. The string "!!! 'Added in automatic mail log purging. This will automatically purge mail logs that are 30 days or older by default'" could not be parsed as it uses an unsupported built-in tag at line 15